### PR TITLE
use field() function for acting_demo and corrected_demo in Event class

### DIFF
--- a/notebooks/toy_model.ipynb
+++ b/notebooks/toy_model.ipynb
@@ -54,7 +54,7 @@
         "import itertools\n",
         "import random\n",
         "\n",
-        "from dataclasses import dataclass\n",
+        "from dataclasses import dataclass, field\n",
         "from typing import List, Union, Tuple, Dict, Optional, Callable\n",
         "import numpy\n",
         "\n",
@@ -369,8 +369,6 @@
         "id": "gSD1z8Cn8FyK"
       },
       "source": [
-        "from dataclasses import dataclass, field\n",
-        "\n",
         "@dataclass\n",
         "class VirtualPersonActivity(object):\n",
         "  \"\"\"Represents a virtual person.\"\"\"\n",

--- a/notebooks/toy_model.ipynb
+++ b/notebooks/toy_model.ipynb
@@ -369,6 +369,8 @@
         "id": "gSD1z8Cn8FyK"
       },
       "source": [
+        "from dataclasses import dataclass, field\n",
+        "\n",
         "@dataclass\n",
         "class VirtualPersonActivity(object):\n",
         "  \"\"\"Represents a virtual person.\"\"\"\n",
@@ -403,8 +405,8 @@
         "  # The following are generated during labeling.\n",
         "  # Initialize here to simplify the attribute updater logic.\n",
         "  acting_user_space: str = None\n",
-        "  acting_demo: DemoBucket = DemoBucket()\n",
-        "  corrected_demo: DemoBucket = DemoBucket()\n",
+        "  acting_demo: DemoBucket = field(default_factory=DemoBucket)\n",
+        "  corrected_demo: DemoBucket = field(default_factory=DemoBucket)\n",
         "\n",
         "  def __str__(self) -> str:\n",
         "    return 'Event: [{}]'.format(',\\n'.join(\n",


### PR DESCRIPTION
 Use the field() function to specify fields such as acting_demo and corrected_demo with mutable default values.

As from Wei's message: 

"This is due to that DemoBucket is mutable, Python stores default member variable values in class attributes and the instances share the same copy.
The fix is to use field() function as below."

Previously, the events had the acting demo and corrected demo filled in before running the model.